### PR TITLE
swap diff outputs

### DIFF
--- a/cmdtest.go
+++ b/cmdtest.go
@@ -320,8 +320,8 @@ func (tf *testFile) compare(log func(string, ...interface{})) string {
 	}
 	buf := new(bytes.Buffer)
 	for _, c := range tf.cases {
-		if diff := cmp.Diff(c.gotOutput, c.wantOutput); diff != "" {
-			fmt.Fprintf(buf, "%s:%d: got=-, want=+\n", tf.filename, c.startLine)
+		if diff := cmp.Diff(c.wantOutput, c.gotOutput); diff != "" {
+			fmt.Fprintf(buf, "%s:%d: want=-, got=+\n", tf.filename, c.startLine)
 			c.writeCommands(buf)
 			fmt.Fprintf(buf, "%s\n", diff)
 		}

--- a/cmdtest_test.go
+++ b/cmdtest_test.go
@@ -107,7 +107,7 @@ func TestRead(t *testing.T) {
 			},
 		},
 	}
-	if diff := cmp.Diff(got, want, cmp.AllowUnexported(TestSuite{}, testFile{}, testCase{})); diff != "" {
+	if diff := cmp.Diff(want, got, cmp.AllowUnexported(TestSuite{}, testFile{}, testCase{})); diff != "" {
 		t.Error(diff)
 	}
 
@@ -131,8 +131,8 @@ func TestCompare(t *testing.T) {
 	}
 	got := err.Error()
 	wants := []string{
-		`testdata.bad.bad-output\.ct:2: got=-, want=+`,
-		`testdata.bad.bad-output\.ct:6: got=-, want=+`,
+		`testdata.bad.bad-output\.ct:2: want=-, got=+`,
+		`testdata.bad.bad-output\.ct:6: want=-, got=+`,
 		`testdata.bad.bad-fail-1\.ct:4: "echo" succeeded, but it was expected to fail`,
 		`testdata.bad.bad-fail-2\.ct:4: "cd foo" failed with chdir`,
 	}
@@ -235,7 +235,7 @@ func diffFiles(t *testing.T, gotFile, wantFile string) string {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return cmp.Diff(string(got), string(want))
+	return cmp.Diff(string(want), string(got))
 }
 
 func mustReadTestSuite(t *testing.T, dir string) *TestSuite {


### PR DESCRIPTION
The current output shows want=+ and got=-, which is really confusing,
since minus denotes elements missing and plus denotes additional
elements, according to go-cmp documentation:

  https://pkg.go.dev/github.com/google/go-cmp/cmp?tab=doc#Diff

Also, in that same documentation, the example provided for Diff uses
minus (-) for "want" and plus (+) for "got". It is also used this way in
other languages.

For comparing values, the "got/want" order makes sense (e.g. errors.Is),
but for printing diffs, using "want/got" makes more sense and is easier
to read.