### PR TITLE
support checking exit codes

### DIFF
--- a/testdata/bad/bad-fail-2.ct
+++ b/testdata/bad/bad-fail-2.ct
@@ -1,6 +1,8 @@
 # Command should not fail, but does.
 # The failure is from the os.Chdir call.
 
+$ echo hello
+
 $ cd foo
 
 # We shouldn't see this output.

--- a/testdata/bad/bad-fail-3.ct
+++ b/testdata/bad/bad-fail-3.ct
@@ -3,5 +3,6 @@
 
 $ cd foo bar
 
+
 # We shouldn't see this output.
 $ echo should not appear

--- a/testdata/bad/bad-fail-4.ct
+++ b/testdata/bad/bad-fail-4.ct
@@ -1,0 +1,6 @@
+# Command should fail with an exit code, but there isn't one.
+
+$ cd foo bar --> FAIL 3
+
+# We shouldn't see this output.
+$ echo should not appear

--- a/testdata/bad/bad-fail-5.ct
+++ b/testdata/bad/bad-fail-5.ct
@@ -1,0 +1,7 @@
+# Command fails, but with the wrong exit code.
+
+$ cd foo --> FAIL 3
+
+# We shouldn't see this output.
+$ echo should not appear
+

--- a/testdata/bad/bad-fail-6.ct
+++ b/testdata/bad/bad-fail-6.ct
@@ -1,0 +1,4 @@
+# Command using ExitCodeErr
+
+$ code17 --> FAIL 4
+

--- a/testdata/bad/bad-fail-7.ct
+++ b/testdata/bad/bad-fail-7.ct
@@ -1,0 +1,3 @@
+# Command using InProcessProgram
+
+$ inprocess99 --> FAIL 5

--- a/testdata/good-without-output/good-without-output.ct
+++ b/testdata/good-without-output/good-without-output.ct
@@ -3,6 +3,9 @@
 # Fails because there is no subdirectory "foo".
 $ cd foo --> FAIL
 
+# ... and it fails with exit code 2.
+$ cd foo --> FAIL 2
+
 $ echo hello world
 
 $ echo now

--- a/testdata/good/good.ct
+++ b/testdata/good/good.ct
@@ -3,6 +3,9 @@
 # Fails because there is no subdirectory "foo".
 $ cd foo --> FAIL
 
+# ... and it fails with exit code 2.
+$ cd foo --> FAIL 2
+
 $ echo hello world
 hello world
 

--- a/testdata/read/read.ct
+++ b/testdata/read/read.ct
@@ -2,8 +2,8 @@
 
 #   Prefix stuff.
 
-$ command arg1 arg2  
-$ cmd2   
+$ command arg1 arg2
+$ cmd2
 out1
 out2
 
@@ -14,6 +14,9 @@ $ c3
 
 $ c4 --> FAIL
 out3
+
+$ c5 --> FAIL 2
+out4
 
 
 # end


### PR DESCRIPTION
Allow tests to specify exit codes on failure, and check
them against the actual exit code.

For built-ins this will just work, because we look for the wrapped
sycall.Errno. For InProcessProgram and user-defined CommandFuncs,
define an error type that holds the exit code and allows it to
be retrieved.