### PR TITLE
support parallel tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ map; keep reading for an example.
 `cmdtest` does its own environment variable substitution, using the syntax
 `${VAR}`. Test execution inherits the full environment of the test binary caller
 (typically, your shell). The environment variable `ROOTDIR` is set to the
-temporary directory created to run the test file.
+temporary directory created to run the test file (except in parallel mode; see
+below).
 
 ## Running the tests
 
@@ -153,3 +154,10 @@ func TestCLI(t *testing.T) {
     ts.Run(t, *update)
 }
 ```
+
+## Parallel mode
+
+If you call `ts.RunParallel` instead of `ts.Run`, each file in the suite is run
+in parallel with the others. (The cases in a single file are still run
+sequentially, however.) In this mode, no temporary directories are created
+and `ROOTDIR` is not set.

--- a/testdata/parallel/par1.ct
+++ b/testdata/parallel/par1.ct
@@ -1,0 +1,5 @@
+$ echo hello world
+hello world
+
+# Fails because there is no subdirectory "foo".
+$ cd foo --> FAIL

--- a/testdata/parallel/par2.ct
+++ b/testdata/parallel/par2.ct
@@ -1,0 +1,4 @@
+$ echo hello world 2
+hello world 2
+
+$ cd bar --> FAIL


### PR DESCRIPTION
Add TestSuite.RunParallel, which runs each test file in parallel. This can significantly speed up some test suites.

This won't work if we create and cd into a temporary directory for each test file, so disable that feature for RunParallel.