### PR TITLE
Add support for file-based test cases

### DIFF
--- a/cmdtest_test.go
+++ b/cmdtest_test.go
@@ -319,6 +319,11 @@ func TestParallel(t *testing.T) {
 	ts.RunParallel(t, false)
 }
 
+func TestFiles(t *testing.T) {
+	ts := mustReadTestSuite(t, "files")
+	ts.Run(t, false)
+}
+
 func diffFiles(t *testing.T, gotFile, wantFile string) string {
 	got, err := ioutil.ReadFile(gotFile)
 	if err != nil {

--- a/testdata/files/files-1.ct
+++ b/testdata/files/files-1.ct
@@ -1,0 +1,2 @@
+$ cat hello.txt
+You see this, because the file was copied to the temporary directory.

--- a/testdata/files/files-1_tf/hello.txt
+++ b/testdata/files/files-1_tf/hello.txt
@@ -1,0 +1,1 @@
+You see this, because the file was copied to the temporary directory.

--- a/testdata/files/files-2.ct
+++ b/testdata/files/files-2.ct
@@ -1,0 +1,5 @@
+# Files are not shared between test cases
+$ cat hello.txt --> FAIL
+
+$ cat bye.txt
+Good bye

--- a/testdata/files/files-2_tf/bye.txt
+++ b/testdata/files/files-2_tf/bye.txt
@@ -1,0 +1,1 @@
+Good bye


### PR DESCRIPTION
Add support for file-based test cases.

Suppose that we have a CLI my-cli that takes a single argument which is a CSV file with an input data.
```bash
my-cli input.csv
```
At the moment there is no easy way to test it.

With this change we will be able to test it like this
```
testdata/
  foo/
    foo_tf/
      sample_input.csv
    foo.ct
```

sample_input.csv will be copied to the foo.ct temporary working directory, so we will be able to call
```
$ my-cli sample_input.csv
```
and check whether it works correctly.

